### PR TITLE
Migration API update

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -19,11 +19,10 @@ echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
 		'min'   => '4.9.0',
-		'max'   => '5.5.3',
+		'max'   => '5.7.2',
 		'other' => [
 			'#^4\.9$#',
-			'#^5\.5\.4-(alpha|beta|rc)#i',
-			'#^5\.6-(alpha|beta|rc)#i',
+			'#^5\.8-(alpha|beta|rc)#i',
 		],
 	],
 	// ClassicPress build to use for migration.
@@ -31,4 +30,14 @@ echo json_encode( [
 		'build'   => $build_url,
 		'version' => $version,
 	],
+	'plugins' => [
+		'wp-config-file-editor/wp-config-file-editor.php',
+		'disable-wp-core-updates-advance/disable-wp-core-updates-advance.php',
+		'disable-wordpress-updates/disable-updates.php',
+		'wp-downgrade/wp-downgrade.php',
+		'wordfence/wordfence.php',
+	],
+	'themes' => [
+		'twentytwentyone',
+	]
 ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );

--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -35,7 +35,6 @@ echo json_encode( [
 		'disable-wp-core-updates-advance/disable-wp-core-updates-advance.php',
 		'disable-wordpress-updates/disable-updates.php',
 		'wp-downgrade/wp-downgrade.php',
-		'wordfence/wordfence.php',
 	],
 	'themes' => [
 		'twentytwentyone',


### PR DESCRIPTION
This patch updates supported WordPress migrations from:
5.5.4, 5.5.5
5.6, 5.6.1, 5.6.2, 5.6.3, 5.6.4
5.7, 5.7.1, 5.7.2

Tested using the core theme TwentyTwenty

It also starts the process of adding incompatible theme and plugin data to the API endpoint that will eventually be used in the Migration plugin.