### PR TITLE
Enable migration from WordPress 5.8 and development versions of 5.9

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -19,10 +19,10 @@ echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
 		'min'   => '4.9.0',
-		'max'   => '5.7.2',
+		'max'   => '5.8',
 		'other' => [
 			'#^4\.9$#',
-			'#^5\.8-(alpha|beta|rc)#i',
+			'#^5\.9-(alpha|beta|rc)#i',
 		],
 	],
 	// ClassicPress build to use for migration.


### PR DESCRIPTION
This change enables migration from the stable WordPress 5.8 branch and also the development (currently alpha) versions of WordPress 5.9.