### PR TITLE
Add `review-widgets-for-trustpilot` plugin slug to conflict API endpoint

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -44,6 +44,7 @@ echo json_encode( [
 		'woocommerce-views/views-woocommerce.php',
 		'cred-commerce/plugin.php',
 		'elementor/elementor.php',
+		'review-widgets-for-trustpilot/review-widgets-for-trustpilot.php',
 	],
 	'themes' => [
 		'twentytwentyone',


### PR DESCRIPTION
This addition to the API added the `review-widgets-for-trustpilot` plugin as a known conflict.