### PR TITLE
Migrate to v1.3.0

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -7,8 +7,8 @@ header( 'Content-Type: application/json' );
 
 // ClassicPress build info. See:
 // https://github.com/ClassyBot/ClassicPress-nightly/releases
-$build_version = '1.1.1';
-$build_date = '20191018';
+$build_version = '1.3.0';
+$build_date = '20210901';
 
 $version = "$build_version+migration.$build_date";
 $build_url = 'https://github.com/ClassyBot/ClassicPress-nightly'


### PR DESCRIPTION
Now that v1.3.0 stable has been released, and the automated nightly _migration_ build corresponding to this version has completed, we can have the migration plugin migrate users directly to v1.3.0.

See: https://github.com/ClassyBot/ClassicPress-nightly/releases/tag/1.3.0%2Bmigration.20210901

Closes https://github.com/ClassicPress/ClassicPress-Migration-Plugin/issues/68.