### PR TITLE
Add support PHP version data to the migration API endpoint

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -32,8 +32,8 @@ echo json_encode( [
 	],
 	'php' => [
 		'min' => '5.6',
-		'max' => '7.4.x',
-		'unsupported' => '8.0',
+		'max' => '7.4.999',
+		'max_display' => '7.4.x',
 	],
 	'plugins' => [
 		'wp-config-file-editor/wp-config-file-editor.php',

--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -30,6 +30,11 @@ echo json_encode( [
 		'build'   => $build_url,
 		'version' => $version,
 	],
+	'php' => [
+		'min' => '5.6',
+		'max' => '7.4.x',
+		'unsupported' => '8.0',
+	],
 	'plugins' => [
 		'wp-config-file-editor/wp-config-file-editor.php',
 		'disable-wp-core-updates-advance/disable-wp-core-updates-advance.php',


### PR DESCRIPTION
This PR adds supported PHP version data to the migration API endpoint with the aim of stopping migration on WordPress sites that are using PHP version 8.0 and higher.