### PR TITLE
Support migrations for WordPress 5.8.1

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -19,7 +19,7 @@ echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
 		'min'   => '4.9.0',
-		'max'   => '5.8',
+		'max'   => '5.8.1',
 		'other' => [
 			'#^4\.9$#',
 			'#^5\.9-(alpha|beta|rc)#i',


### PR DESCRIPTION
In local tests and apparently in a case on the forum, migration from 5.8.1 is successful, we should offer official support.

https://forums.classicpress.net/t/advanced-option-in-migration-plugin/3594 