### PR TITLE
Update endpoint for 5.9 and testing for presumed 6.0

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -19,10 +19,10 @@ echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
 		'min'   => '4.9.0',
-		'max'   => '5.8.1',
+		'max'   => '5.9',
 		'other' => [
 			'#^4\.9$#',
-			'#^5\.9-(alpha|beta|rc)#i',
+			'#^6\.0-(alpha|beta|rc)#i',
 		],
 	],
 	// ClassicPress build to use for migration.


### PR DESCRIPTION
I have manually tested migration from:

WordPress 5.9-RC1-52464

To the current migration release:
ClassicPress 1.3.1+migration.20211021

I saw no errors, admin screens for posts, plugins and themes are all still as expected and loading of several front end pages were all visually as expected.