### PR TITLE
Add migration support from WP 6.0

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -19,10 +19,10 @@ echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
 		'min'   => '4.9.0',
-		'max'   => '5.9',
+		'max'   => '6.0',
 		'other' => [
 			'#^4\.9$#',
-			'#^6\.0-(alpha|beta|rc)#i',
+			'#^6\.1-(alpha|beta|rc)#i',
 		],
 	],
 	// ClassicPress build to use for migration.


### PR DESCRIPTION
This PR updates the migration API to enable migrations from WordPress 6.0 and 6.1 development versions.