### PR TITLE
Add API endpoint for PHP version support checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /v1/features/1.0/petitions-order-*.json
 /v1/twemoji/*.json
 /v1/upgrade/*.json
+.DS_store

--- a/v1/core/support-check/1.0/index.php
+++ b/v1/core/support-check/1.0/index.php
@@ -9,12 +9,71 @@
  *  'is_secure' - boolean - Whether the PHP version receives security updates.
  *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for ClassicPress.
  */
-$json = [
-    'recommended_version' => '5.6',
-    'is_supported'        => true,
-    'is_secure'           => false,
-    'is_acceptable'       => false,
-];
+
+ // No php version passed.
+if ( ! isset( $_GET['php_version'] ) ) {
+    $json = [
+        'code'    => 'missing_param',
+        'message' => 'Missing parameter: ' . $_GET['php_version'],
+        'status'  => 400
+    ];
+    header('Content-Type: application/json');
+    echo json_encode($json);
+
+    return;
+}
+
+$php_version              = $_GET['php_version'];
+$recommended_version      = '7.4';
+$latest_supported_version = '8.0';
+
+// Allowed set of details.
+$allowed_php_versions_for_check = ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1','8.2'];
+
+if ( ! in_array( $php_version, $allowed_php_versions_for_check ) ) {
+    $json = [
+        'code'    => 'missing_param',
+        'message' => 'Unsupported Version: ' . $php_version,
+        'status'  => 400
+    ];
+    header('Content-Type: application/json');
+    echo json_encode($json);
+
+    return;
+}
+
+// For versions less than 7.4 in array not recommended.
+if ( floatval( $php_version ) > 7.4 ) {
+    $json = [
+        'recommended_version' => $recommended_version,
+        'is_supported'        => true,
+        'is_secure'           => false,
+        'is_acceptable'       => false,
+    ];
+}
+
+/**
+ * For versions greater than 7.3 in array recommended and supported.
+ * Change this when 7.4 is deprecated.
+ */
+if ( floatval( $php_version ) >= 7.4 ) {
+    $json = [
+        'recommended_version' => $recommended_version,
+        'is_supported'        => true,
+        'is_secure'           => true,
+        'is_acceptable'       => true,
+    ];
+}
+
+// For versions greater than 7.3 in array recommended and not supported.
+if ( floatval( $php_version ) > $latest_supported_version ) {
+    $json = [
+        'recommended_version' => $recommended_version,
+        'is_supported'        => false,
+        'is_secure'           => true,
+        'is_acceptable'       => true,
+    ];
+}
 
 header('Content-Type: application/json');
 echo json_encode($json);

--- a/v1/core/support-check/1.0/index.php
+++ b/v1/core/support-check/1.0/index.php
@@ -10,10 +10,10 @@
  *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for ClassicPress.
  */
 $json = [
-    'recommended_version' => '7.4',
+    'recommended_version' => '5.6',
     'is_supported'        => true,
-    'is_secure'           => true,
-    'is_acceptable'       => true,
+    'is_secure'           => false,
+    'is_acceptable'       => false,
 ];
 
 header('Content-Type: application/json');

--- a/v1/core/support-check/1.0/index.php
+++ b/v1/core/support-check/1.0/index.php
@@ -43,7 +43,7 @@ if ( ! in_array( $php_version, $allowed_php_versions_for_check ) ) {
 }
 
 // For versions less than 7.4 in array not recommended.
-if ( floatval( $php_version ) > 7.4 ) {
+if ( floatval( $php_version ) <= 7.3 ) {
     $json = [
         'recommended_version' => $recommended_version,
         'is_supported'        => true,

--- a/v1/core/support-check/1.0/index.php
+++ b/v1/core/support-check/1.0/index.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * REST API Endpoint used to check the recommended ClassicPress PHP version.
+ * This is similar to http://api.wordpress.org/core/serve-happy/1.0/ 
+ *
+ * Response should be an array with:
+ *  'recommended_version' - string - The PHP version recommended by ClassicPress.
+ *  'is_supported' - boolean - Whether the PHP version is actively supported.
+ *  'is_secure' - boolean - Whether the PHP version receives security updates.
+ *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for ClassicPress.
+ */
+$json = [
+    'recommended_version' => '7.4',
+    'is_supported'        => true,
+    'is_secure'           => true,
+    'is_acceptable'       => true,
+];
+
+header('Content-Type: application/json');
+echo json_encode($json);

--- a/v1/core/support-check/index.php
+++ b/v1/core/support-check/index.php
@@ -1,0 +1,2 @@
+<?php
+header('Location: /');

--- a/v1/index.php
+++ b/v1/index.php
@@ -6,6 +6,7 @@ $endpoints = [
     '/checksums/',
     '/core/stable-check/1.0/',
     '/core/version-check/1.0/',
+    '/core/support-check/1.0/',
     '/events/1.0/',
     '/features/1.0/',
     '/secret-key/1.0/salt/',


### PR DESCRIPTION
## Description
I would like to pursue this https://github.com/ClassicPress/ClassicPress/pull/624 further. 

This adds an API endpoint for PHP version support check.

## Motivation
- Limited devs. If we can get more of the users to get to 7.4 minimum we can drop the support for older PHP soon
- Keep everyone safer (to a degree of course)

This API mainly will feed the `wp_check_php_version()` in `src/wp-admin/includes/dashboard.php` to display a dashboard widget when the PR highlighted above is approved.

The function requires an API with a response:
```
/**
 * Response should be an array with:
 *  'recommended_version' - string - The PHP version recommended by ClassicPress.
 *  'is_supported' - boolean - Whether the PHP version is actively supported.
 *  'is_secure' - boolean - Whether the PHP version receives security updates.
 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for ClassicPress.
 */
```

## Test
On test with the linked [PR #624](https://github.com/ClassicPress/ClassicPress/pull/624)

`is_acceptable` is true will remove the dashboard widget.

![Screenshot 2022-07-18 at 20 24 13](https://user-images.githubusercontent.com/7713923/179568516-c40c3149-05cb-4874-8644-c72c5af949d8.png)

`is_secure` is true will add a warning.

![Screenshot 2022-07-18 at 20 23 45](https://user-images.githubusercontent.com/7713923/179568542-a37fc7b7-e1cf-4951-92ed-60cd7177d197.png)

![Screenshot 2022-07-18 at 20 23 28](https://user-images.githubusercontent.com/7713923/179568550-a44bffab-4a80-41b5-a6f4-aaf415a0d13b.png)

## UPDATED API requirements
See: https://github.com/ClassicPress/ClassicPress-APIs/pull/51#issuecomment-1315505814