### PR TITLE
Add v2 nightly repository in json generation

### DIFF
--- a/v1-upgrade-generator/README.md
+++ b/v1-upgrade-generator/README.md
@@ -25,6 +25,7 @@ The script relies on a couple of `git` repositories being in place:
 ```
 cd v1-upgrade-generator/
 git clone https://github.com/ClassyBot/ClassicPress-nightly ClassicPress-nightly
+git clone https://github.com/ClassyBot/ClassicPress-v2-nightly ClassicPress-v2-nightly
 git clone https://github.com/ClassicPress/ClassicPress-release ClassicPress-release
 ```
 

--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -33,8 +33,10 @@ def write_upgrade_json(ver, action):
     filename = upgrade_json_filename(ver, action)
     print 'write_upgrade_json(%s)' % os.path.basename(filename)
 
-    if '+nightly' in str(ver):
+    if ('+nightly' in str(ver) and ver.startswith('1')):
         url = 'https://github.com/ClassyBot/ClassicPress-nightly/archive/%s.zip' % ver
+    elif ('+nightly' in str(ver) and ver.startswith('2')):
+        url = 'https://github.com/ClassyBot/ClassicPress-v2-nightly/archive/%s.zip' % ver
     else:
         url = 'https://github.com/ClassicPress/ClassicPress-release/archive/%s.zip' % ver
 

--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -33,9 +33,9 @@ def write_upgrade_json(ver, action):
     filename = upgrade_json_filename(ver, action)
     print 'write_upgrade_json(%s)' % os.path.basename(filename)
 
-    if ('+nightly' in str(ver) and ver.startswith('1')):
+    if ('+nightly' in str(ver) and str(ver).startswith('1')):
         url = 'https://github.com/ClassyBot/ClassicPress-nightly/archive/%s.zip' % ver
-    elif ('+nightly' in str(ver) and ver.startswith('2')):
+    elif ('+nightly' in str(ver) and str(ver).startswith('2')):
         url = 'https://github.com/ClassyBot/ClassicPress-v2-nightly/archive/%s.zip' % ver
     else:
         url = 'https://github.com/ClassicPress/ClassicPress-release/archive/%s.zip' % ver

--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -133,25 +133,29 @@ with load_repo('ClassicPress-nightly') as r_nightly:
     for (tag, sha) in r_nightly.refs.as_dict('refs/tags').iteritems():
         tags[tag] = {'repo': r_nightly, 'sha': sha}
 
-    with load_repo('ClassicPress-release') as r_release:
-        for (tag, sha) in r_release.refs.as_dict('refs/tags').iteritems():
-            tags[tag] = {'repo': r_release, 'sha': sha}
+with load_repo('ClassicPress-v2-nightly') as r2_nightly:
+    for (tag, sha) in r2_nightly.refs.as_dict('refs/tags').iteritems():
+       tags[tag] = {'repo': r2_nightly, 'sha': sha}
 
-        dump('tags', dict((t, tags[t]['sha']) for t in tags))
+with load_repo('ClassicPress-release') as r_release:
+    for (tag, sha) in r_release.refs.as_dict('refs/tags').iteritems():
+        tags[tag] = {'repo': r_release, 'sha': sha}
 
-        for tag in tags:
-            write_checksums_json(tag, tags[tag])
-            try:
-                ver = semver.parse_version_info(tag)
-                # we only care about release and nightly builds
-                if not ver.build or ver.build[:7] == 'nightly':
-                    if ver.major in vers:
-                        vers[ver.major].append(ver)
-                    else:
-                        vers[ver.major] = [ver]
-            except ValueError:
-                # ignore non-semver tags
-                pass
+dump('tags', dict((t, tags[t]['sha']) for t in tags))
+
+for tag in tags:
+    write_checksums_json(tag, tags[tag])
+    try:
+        ver = semver.parse_version_info(tag)
+        # we only care about release and nightly builds
+        if not ver.build or ver.build[:7] == 'nightly':
+            if ver.major in vers:
+                vers[ver.major].append(ver)
+            else:
+                vers[ver.major] = [ver]
+    except ValueError:
+        # ignore non-semver tags
+        pass
 
 dump('vers', dict((major, sorted(str(v) for v in arr)) for (major, arr) in vers.iteritems()))
 

--- a/v1-upgrade-generator/update.sh
+++ b/v1-upgrade-generator/update.sh
@@ -16,6 +16,10 @@ pushd ClassicPress-nightly
 	git fetch
 	git fetch --tags
 popd
+pushd ClassicPress-v2-nightly
+	git fetch
+	git fetch --tags
+popd
 pushd ClassicPress-release
 	git fetch
 	git fetch --tags


### PR DESCRIPTION
These changes add the ClassicPress-v2 repository to enure the API is updated for V2.x.x nightly builds and any future releases.