### PR TITLE
Dynamic php_version based on CP version

### DIFF
--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -40,6 +40,11 @@ def write_upgrade_json(ver, action):
     else:
         url = 'https://github.com/ClassicPress/ClassicPress-release/archive/%s.zip' % ver
 
+    if (str(ver).startswith('1')):
+        php_version = '5.6.4'
+    else:
+        php_version = '7.4'
+
     with open(filename + '.tmp', 'w') as json_file:
         json_file.write("""\
 {{
@@ -57,13 +62,13 @@ def write_upgrade_json(ver, action):
         }},
         "current":"{ver}",
         "version":"{ver}",
-        "php_version":"5.6.4",
+        "php_version":"{php_version}",
         "mysql_version":"5.0",
         "new_bundled":"4.7",
         "partial_version":false
     }}
 ]
-}}""".format(action=action, url=url, ver=str(ver)))
+}}""".format(action=action, url=url, ver=str(ver), php_version=str(php_version)))
 
     os.rename(filename + '.tmp', filename)
 


### PR DESCRIPTION
This PR will create a correct entry for the `php_version` parameter in the served json files for version 2.0.0 and above.

Currently a static PHP version variable is used, we should be accurate in this variable and also dynamic to account for CP 1.x.x.and CP 2.x.x

This edit has been tested on the test API server.