### PR TITLE
Use renamed branch for PR creation

### DIFF
--- a/.github/workflows/classicpress-release.yml
+++ b/.github/workflows/classicpress-release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          base: master
+          base: main
           branch: release/${{ env.current_version }}
           commit-message: Update API for ClassicPress ${{ env.current_version }} release
           title: Update API for ClassicPress ${{ env.current_version }} release


### PR DESCRIPTION
The GitHub action for automatic detection of a new ClassicPress release are failing following an upstream branch name change.

This PR aims to address that and get the process working again.