### PR TITLE
Fix checksum generation

### DIFF
--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -88,12 +88,13 @@ def write_checksums_json(tag, tag_data):
     repo = tag_data['repo']
     tag_or_commit = repo.commit(tag_sha)
     checksums = {}
+    blobs = list(tag_or_commit.tree.traverse())
 
-    for blob in tag_or_commit.tree.blobs:
+    for blob in blobs:
         file_path = blob.path
         sha = blob.hexsha
         hash_md5 = hashlib.md5()
-        hash_md5.update(repo.git.show(sha).encode())
+        hash_md5.update(repo.git.show(sha).encode('raw_unicode_escape'))
         checksums[file_path] = hash_md5.hexdigest()
 
     with open(json_filename + '.tmp', 'w') as json_file:


### PR DESCRIPTION
This PR aims to fix 2 issues in the generation of checksums for code releases.

Only the root files are having a checksum generated at the moment, this change ensure the script recurses through full git tree.
Since the introduction of a favicon in root, the script is failing due to Python encoding errors, this change encodes files accounting for non-text files.