### PR TITLE
Fix: Use renamed branch for WordPress PR creation

### DIFF
--- a/.github/workflows/wordpress-release.yml
+++ b/.github/workflows/wordpress-release.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          base: master
+          base: main
           branch: wprelease/${{ env.current_version }}
           commit-message: Update API for new WordPress ${{ env.current_version }} Release
           title: Update API for WordPress ${{ env.current_version }} release


### PR DESCRIPTION
Similar to:
https://github.com/ClassicPress/ClassicPress-APIs/pull/88

This PR corrects the branch used for PR creation when new WordPress releases are detected.