### PR TITLE
Skip folders when creating MD5 hashes

### DIFF
--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -91,6 +91,8 @@ def write_checksums_json(tag, tag_data):
     blobs = list(tag_or_commit.tree.traverse())
 
     for blob in blobs:
+        if blob.type == "tree":
+            continue
         file_path = blob.path
         sha = blob.hexsha
         hash_md5 = hashlib.md5()


### PR DESCRIPTION
MD5 hashes are being created in the current code including folders, this is incorrect, the MD5 should be created for files only.

This PR has been implemented manually on the Test and main API servers and fixes the above issue.