### PR TITLE
Fix Python error when releasing pre-release code

### DIFF
--- a/v1-upgrade-generator/generate-upgrade-json.py
+++ b/v1-upgrade-generator/generate-upgrade-json.py
@@ -180,7 +180,7 @@ for major, version_list in vers.items():
                 vecs[major][str(version)] = str(max_bld_ver)
                 symlink_versions(max_bld_ver, 'upgrade', version)
         elif version.prerelease:
-            if version < max_rel_ver:
+            if max_rel_ver is not None and version < max_rel_ver:
                 vecs[major][str(version)] = str(max_rel_ver)
                 symlink_versions(max_rel_ver, 'upgrade', version)
             elif version != max_pre_ver:


### PR DESCRIPTION
During the release process for 2.0.0.-rc1 the following error eas seen on the API server when the JSON endpint script ran:
```
Traceback (most recent call last):
  File "/var/www/html/ClassicPress-APIs-Test/v1-upgrade-generator/generate-upgrade-json.py", line 185, in <module>
    if version < max_rel_ver:
TypeError: '<' not supported between instances of 'VersionInfo' and 'NoneType'`
```

This change fixed the error message.