### PR TITLE
Use v2 nightly builds for migration checks

### DIFF
--- a/.github/workflows/classicpress-release.yml
+++ b/.github/workflows/classicpress-release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Check release repository
         run: |
           echo "Collect and process json"
-          RELEASE_URL=$(wget -cq "https://api.github.com/repos/ClassyBot/ClassicPress-v1-nightly/releases?per_page=3" -O - | jq -r '.[].html_url' | grep '%2Bnightly\.' | head -n1)
+          RELEASE_URL=$(wget -cq "https://api.github.com/repos/ClassyBot/ClassicPress-v2-nightly/releases?per_page=3" -O - | jq -r '.[].html_url' | grep '%2Bnightly\.' | head -n1)
           CURRENT_VERSION=$(echo "${RELEASE_URL}" | sed 's#.*/##; s#%2B.*##')
           RELEASE_DATE=$(echo "${RELEASE_URL: -8}")
           if [ -z "$CURRENT_VERSION" ] || [ -z "$RELEASE_DATE" ]; then

--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -6,12 +6,12 @@ header( 'Content-Type: application/json' );
 // the migration plugin other than updating these parameters.
 
 // ClassicPress build info. See:
-// https://github.com/ClassyBot/ClassicPress-v1-nightly/releases
+// https://github.com/ClassyBot/ClassicPress-v2-nightly/releases
 $build_version = '1.7.2';
 $build_date = '20240131';
 
 $version = "$build_version+migration.$build_date";
-$build_url = 'https://github.com/ClassyBot/ClassicPress-v1-nightly'
+$build_url = 'https://github.com/ClassyBot/ClassicPress-v2-nightly'
 	. "/releases/download/$build_version%2Bmigration.$build_date"
 	. "/ClassicPress-nightly-$build_version-migration.$build_date.zip";
 


### PR DESCRIPTION
A GitHub action currently checks for new ClassicPress (and WordPress) releases and creates a PR automatically for the migration plugin API.

This PR updated the ClassicPress checks moving to the `v2` releases with the release of "Bella". This will alter behaviour of the migration plugin for new users and migrate site to `v2` of ClassicPress.