### PR TITLE
Add importers endpoint for ClassicPress v2

### DIFF
--- a/v1/core/importers/2.0/index.php
+++ b/v1/core/importers/2.0/index.php
@@ -1,0 +1,60 @@
+<?php
+header('Content-Type: application/json');
+
+// A list of importer plugins used in the core.
+// WordPress API: https://api.wordpress.org/core/importers/1.1/
+// Used in /wp-admin/includes/import.php
+
+echo json_encode([
+    "importers" => [
+        "blogger" => [
+            "name" => "Blogger",
+            "description" => "Install the Blogger importer to import posts, comments, and users from a Blogger blog.",
+            "plugin-slug" => "blogger-importer",
+            "importer-id" => "blogger"
+        ],
+        "wpcat2tag" => [
+            "name" => "Categories and Tags Converter",
+            "description" => "Install the category/tag converter to convert existing categories to tags or tags to categories, selectively.",
+            "plugin-slug" => "wpcat2tag-importer",
+            "importer-id" => "wpcat2tag"
+        ],
+        "livejournal" => [
+            "name" => "LiveJournal",
+            "description" => "Install the LiveJournal importer to import posts from LiveJournal using their API.",
+            "plugin-slug" => "livejournal-importer",
+            "importer-id" => "livejournal"
+        ],
+        "movabletype" => [
+            "name" => "Movable Type and TypePad",
+            "description" => "Install the Movable Type importer to import posts and comments from a Movable Type or TypePad blog.",
+            "plugin-slug" => "movabletype-importer",
+            "importer-id" => "mt"
+        ],
+        "opml" => [
+            "name" => "Blogroll",
+            "description" => "Install the blogroll importer to import links in OPML format.",
+            "plugin-slug" => "opml-importer",
+            "importer-id" => "opml"
+        ],
+        "rss" => [
+            "name" => "RSS",
+            "description" => "Install the RSS importer to import posts from an RSS feed.",
+            "plugin-slug" => "rss-importer",
+            "importer-id" => "rss"
+        ],
+        "tumblr" => [
+            "name" => "Tumblr",
+            "description" => "Install the Tumblr importer to import posts & media from Tumblr using their API.",
+            "plugin-slug" => "tumblr-importer",
+            "importer-id" => "tumblr"
+        ],
+        "wordpress" => [
+            "name" => "WordPress",
+            "description" => "Install the WordPress importer to import posts, pages, comments, custom fields, categories, and tags from a WordPress export file.",
+            "plugin-slug" => "wordpress-importer",
+            "importer-id" => "wordpress"
+        ]
+    ],
+    "translated" => false
+], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/v1/index.php
+++ b/v1/index.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/functions.php';
 $endpoints = [
     '/checksums/',
     '/core/importers/1.0/',
+    '/core/importers/2.0/',
     '/core/stable-check/1.0/',
     '/core/version-check/1.0/',
     '/events/1.0/',


### PR DESCRIPTION
See [WordPress/ClassicPress (WXR) Import Tool](https://github.com/ClassicPress/ClassicPress/issues/1339#top).

In ClassicPress v1 WordPress importer [must be installed manually](https://docs.classicpress.net/user-guides/using-classicpress/tools-import-screen/) as v0.7 is needed.

In ClassicPress v2 WordPress importer v0.8.2 (latest) works.

This PR adds a new endpoint so ClassicPress v2 can automatically install it from the "import" page.