### PR TITLE
Add linked migration options

### DIFF
--- a/.github/workflows/classicpress-release.yml
+++ b/.github/workflows/classicpress-release.yml
@@ -6,10 +6,10 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  release-check:
+  v2-release-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Check release repository
+      - name: Check v2 release repository
         run: |
           echo "Collect and process json"
           RELEASE_URL=$(wget -cq "https://api.github.com/repos/ClassyBot/ClassicPress-v2-nightly/releases?per_page=3" -O - | jq -r '.[].html_url' | grep '%2Bnightly\.' | head -n1)
@@ -30,10 +30,21 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
         if: ${{ env.proceed == 'true' }}
+
+      - name: Compare to Repository
+        if: ${{ env.proceed == 'true' }}
+        run: |
+          API_VERSION=$(grep '^\$build_version =' v1/migration/index.php | cut -d\' -f2)
+          if [ "${{ env.current_version }}" != "${API_VERSION}" ]; then
+            sed -ri "s#^\\\$build_version =.*\$#\$build_version = '${{ env.current_version }}';#" v1/migration/index.php
+            sed -ri "s#^\\\$build_date =.*\$#\$build_date = '${{ env.release_date }}';#" v1/migration/index.php
+          else
+            echo "proceed=false" >> $GITHUB_ENV
+          fi
 
       - name: Check for current Pull Request
         if: ${{ env.proceed == 'true' }}
@@ -44,18 +55,9 @@ jobs:
             echo "proceed=false" >> $GITHUB_ENV
           fi
 
-      - name: Compare to Repository
-        if: ${{ env.proceed == 'true' }}
-        run: |
-          API_VERSION=$(grep '^\$build_version =' v1/migration/index.php | cut -d\' -f2)
-          if [ "${{ env.current_version }}" != "${API_VERSION}" ]; then
-            sed -ri "s#^\\\$build_version =.*\$#\$build_version = '${{ env.current_version }}';#" v1/migration/index.php
-            sed -ri "s#^\\\$build_date =.*\$#\$build_date = '${{ env.release_date }}';#" v1/migration/index.php
-          fi
-
       - name: Create Pull Request
         id: createpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         if: ${{ env.proceed == 'true' }}
         with:
           committer: GitHub <noreply@github.com>
@@ -66,6 +68,72 @@ jobs:
           title: Update API for ClassicPress ${{ env.current_version }} release
           body: |
             Update API endpoint for migration
-            - Update release version to ${{ env.current_version }}
-            - Update release date to ${{ env.release_date }}
+            - Update v2 release version to ${{ env.current_version }}
+            - Update v2 release date to ${{ env.release_date }}
+            See also https://github.com/ClassicPress/ClassicPress-APIs/pull/38.
+
+  v1-release-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check v1 release repository
+        run: |
+          echo "Collect and process json"
+          RELEASE_URL=$(wget -cq "https://api.github.com/repos/ClassyBot/ClassicPress-v1-nightly/releases?per_page=3" -O - | jq -r '.[].html_url' | grep '%2Bnightly\.' | head -n1)
+          CURRENT_VERSION=$(echo "${RELEASE_URL}" | sed 's#.*/##; s#%2B.*##')
+          RELEASE_DATE=$(echo "${RELEASE_URL: -8}")
+          if [ -z "$CURRENT_VERSION" ] || [ -z "$RELEASE_DATE" ]; then
+            echo "Determining release info FAILED!"
+            exit 1
+          fi
+          if [[ "$CURRENT_VERSION" = *-* ]]; then
+            echo "Latest nightly version is beta/RC/etc: $CURRENT_VERSION"
+            echo "Not proceeding!"
+            echo "proceed=false" >> $GITHUB_ENV
+          else
+            echo "current_version=${CURRENT_VERSION}" >> $GITHUB_ENV
+            echo "release_date=${RELEASE_DATE}" >> $GITHUB_ENV
+            echo "proceed=true" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        if: ${{ env.proceed == 'true' }}
+
+      - name: Compare to Repository
+        if: ${{ env.proceed == 'true' }}
+        run: |
+          API_VERSION=$(grep '^\$v1_build_version =' v1/migration/index.php | cut -d\' -f2)
+          if [ "${{ env.current_version }}" != "${API_VERSION}" ]; then
+            sed -ri "s#^\\\$v1_build_version =.*\$#\$v1_build_version = '${{ env.current_version }}';#" v1/migration/index.php
+            sed -ri "s#^\\\$v1_build_date =.*\$#\$v1_build_date = '${{ env.release_date }}';#" v1/migration/index.php
+          else
+            echo "proceed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check for current Pull Request
+        if: ${{ env.proceed == 'true' }}
+        run: |
+          BRANCHES=$(git branch -a)
+          if [[ "$BRANCHES" = *release/${{ env.current_version }}* ]]; then
+            echo 'Update API PR already exists'
+            echo "proceed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Create Pull Request
+        id: createpr
+        uses: peter-evans/create-pull-request@v6
+        if: ${{ env.proceed == 'true' }}
+        with:
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          base: main
+          branch: release/${{ env.current_version }}
+          commit-message: Update API for ClassicPress ${{ env.current_version }} release
+          title: Update API for ClassicPress ${{ env.current_version }} release
+          body: |
+            Update API endpoint for migration
+            - Update v1 release version to ${{ env.current_version }}
+            - Update v1 release date to ${{ env.release_date }}
             See also https://github.com/ClassicPress/ClassicPress-APIs/pull/38.

--- a/.github/workflows/wordpress-release.yml
+++ b/.github/workflows/wordpress-release.yml
@@ -6,18 +6,24 @@ on:
     - cron: '0 1 * * *'
 
 jobs:
-  release-check:
+  wp-release-check:
     runs-on: ubuntu-latest
     steps:
       - name: Check release repository
         run: |
           echo "Collect and process json"
-          RELEASE_DATA=$(wget -cq "https://api.wordpress.org/core/version-check/1.7/" -O - | jq --compact-output '.["offers"] | limit( 1; .[] ) | {current}')
+          API_DATA=$(wget -cq "https://api.wordpress.org/core/version-check/1.7/" -O -)
+          RELEASE_DATA=$(echo ${API_DATA} | jq --compact-output '.["offers"] | limit( 1; .[] ) | {current}')
           CURRENT_DATA=$(echo ${RELEASE_DATA} | grep -Eo -m1 '[[:digit:]]+\.[[:digit:]]+\.?[[:digit:]]*')
+          VERSION_DATA=$(echo ${API_DATA} | jq --compact-output '.["offers"] | map_values( {version} )')
+          WP49_VERSION=$(echo ${VERSION_DATA} | grep -Eo -m1 '[4]\.[9]\.[[:digit:]]+')
+          WP62_VERSION=$(echo ${VERSION_DATA} | grep -Eo -m1 '[6]\.[2]\.[[:digit:]]+')
           echo "current_version=${CURRENT_DATA}" >> $GITHUB_ENV
+          echo "wp49_version=${WP49_VERSION}" >> $GITHUB_ENV
+          echo "wp62_version=${WP62_VERSION}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,6 +31,8 @@ jobs:
         run: |
           MAX_WP_VERSION=$(grep 'max' v1/migration/index.php | head -n 1)
           WP_VERSION=$(echo "${MAX_WP_VERSION}" | cut -d\' -f4)
+          WP49_VERSION=$(grep '$wp49' v1/migration/index.php | head -n 1 | grep -Eo -m1 '[4]+\.[9]+\.?[[:digit:]]*')
+          WP62_VERSION=$(grep '$wp62' v1/migration/index.php | head -n 1 | grep -Eo -m1 '[6]+\.[2]+\.?[[:digit:]]*')
 
           if [ "${{ env.current_version }}" != "${WP_VERSION}" ]; then
             echo "proceed=true" >> $GITHUB_ENV
@@ -40,6 +48,12 @@ jobs:
             NEW_TEST=$(echo "${NEW_TEST_VERSION}-(alpha" | sed 's|\\|\\\\|g')
             CURRENT_TEST=$(echo "${MINOR_VERSION}-(alpha" | sed 's|\.|\\\\.|g')
             sed -i "s|${CURRENT_TEST}|${NEW_TEST}|" v1/migration/index.php
+            if [ "${{ env.wp49_version }}" != "${WP49_VERSION}" ]; then
+              sed -i "s|wordpress-${WP49_VERSION}|wordpress-${{ env.wp49_version }}|" v1/migration/index.php
+            fi
+            if [ "${{ env.wp62_version }}" != "${WP62_VERSION}" ]; then
+              sed -i "s|wordpress-${WP62_VERSION}|wordpress-${{ env.wp62_version }}|" v1/migration/index.php
+            fi
           else
             echo "Migration from WordPress ${{ env.current_version }} is already supported"
             echo "proceed=false" >> $GITHUB_ENV
@@ -56,7 +70,7 @@ jobs:
 
       - name: Create Pull Request
         id: createpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v6
         if: ${{ env.proceed == 'true' }}
         with:
           committer: GitHub <noreply@github.com>

--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -15,6 +15,20 @@ $build_url = 'https://github.com/ClassyBot/ClassicPress-v2-nightly'
 	. "/releases/download/$build_version%2Bmigration.$build_date"
 	. "/ClassicPress-nightly-$build_version-migration.$build_date.zip";
 
+// ClassicPress build info. See:
+// https://github.com/ClassyBot/ClassicPress-v1-nightly/releases
+$v1_build_version = '1.7.2';
+$v1_build_date = '20240131';
+
+$v1_version = "$v1_build_version+migration.$v1_build_date";
+$v1_build_url = 'https://github.com/ClassyBot/ClassicPress-v1-nightly'
+	. "/releases/download/$v1_build_version%2Bmigration.$v1_build_date"
+	. "/ClassicPress-nightly-$v1_build_version-migration.$v1_build_date.zip";
+
+$wp49 = "https://wordpress.org/wordpress-4.9.25.zip";
+
+$wp62 = "https://wordpress.org/wordpress-6.2.3.zip";
+
 echo json_encode( [
 	// WordPress versions allowed for migration.
 	'wordpress' => [
@@ -34,6 +48,13 @@ echo json_encode( [
 		'min' => '7.4',
 		'max' => '8.3.999',
 		'max_display' => '8.3.x',
+	],
+	'links' => [
+		'ClassicPress v2'  => $build_url,
+		'ClassicPress v1'  => $v1_build_url,
+		'WordPress Latest' => 'https://wordpress.org/latest.zip',
+		'WordPress 6.2.x'  => $wp62,
+		'WordPress 4.9.x'  => $wp49,
 	],
 	'plugins' => [
 		'wp-config-file-editor/wp-config-file-editor.php',


### PR DESCRIPTION
This PR extend the API migration endpoint to deliver several linked migration options for a drop down in the migration plugin.

These additional options include the last major release of ClassicPress (currently 1.7.2) and the original WordPress versions forked for ClassicPress `v1` (WP 4.9.x) and ClassicPress `v2`(WP 6.2.x) - latest patch version of each respectively.

While making these changes, the GitHub actions in use have been updated to latest versions, process steps have been renamed slightly for clarify and step ordering has been updated for faster exit f there is no update.