### PR TITLE
Add new endpoint querying GH issues for the dashboard widget.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /v1/twemoji/*.json
 /v1/upgrade/*.json
 .idea/*
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /v1/features/1.0/petitions-order-*.json
 /v1/twemoji/*.json
 /v1/upgrade/*.json
+.idea/*

--- a/v1/feature-requests/1.0/index.php
+++ b/v1/feature-requests/1.0/index.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Get issues from the ClassicPress GitHub repository that are labeled as feature requests.
+ */
+
+$github_owner    = 'ClassicPress';
+$github_repo     = 'ClassicPress';
+$github_app_name = '';
+$github_token    = '';
+
+/**
+ * If empty string is returned, then the issue has no label.
+ *
+ * @param $issue GH Issue.
+ *
+ * @return string Label with status: in it.
+ */
+function get_label_status( $issue ) {
+    $label = array_reduce($issue['labels'], function ($carry, $item) {
+        return strpos($item['name'], 'status:') === 0 ? $item['name'] : $carry;
+    }, '');
+
+    return str_replace('status:', '', $label);
+}
+
+/**
+ * @param string $url             GitHub API URL.
+ * @param string $github_token    GitHub token.
+ * @param string $github_app_name GitHub app name.
+ *
+ * @return array API data returned.
+ */
+function http_get_request($url, $github_token, $github_app_name) {
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        'Accept: application/vnd.github+json',
+        'Authorization: Bearer ' . $github_token,
+        'X-GitHub-Api-Version: 2022-11-28',
+        'User-Agent: ' . $github_app_name
+    ));
+    curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
+
+    $response    = curl_exec( $ch );
+    $status_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+
+    if ( $status_code !== 200 ) {
+        return [ 'error' => $status_code ];
+    } else {
+        return json_decode( $response, true );
+    }
+
+    curl_close($ch);
+    return $response;
+}
+
+$url      = "https://api.github.com/repos/{$github_owner}/{$github_repo}/issues";
+$responseArray = http_get_request( $url, $github_token, $github_app_name );
+
+// Implement some kind of cache here to avoid hitting the GitHub API rate limit.
+if ( ! is_countable( $responseArray ) || count( $responseArray ) < 1 || isset( $responseArray['error'] ) ) {
+    $json = [
+        'data'       => 'No feature requests found.',
+        'error_code' => $responseArray['error'],
+    ];
+} else {
+    $featureRequests = [];
+
+    foreach ($responseArray as $issue) {
+        $featureRequests[] = [
+            'title'  => $issue['title'],
+            'status' => trim( get_label_status( $issue ) ), // get a string with status: in it
+            'link'   => $issue['html_url'],
+        ];
+    }
+
+    $json['feature-requests'] = [
+        'recent' => [
+            'data' => $featureRequests,
+        ],
+        'link' => "https://github.com/{$github_owner}/{$github_repo}/issues?q=is%3Aopen+is%3Aissue+label%3A%22type%3A+feature+request%22",
+    ];
+}
+
+header('Content-Type: application/json');
+echo json_encode($json);

--- a/v1/feature-requests/index.php
+++ b/v1/feature-requests/index.php
@@ -1,0 +1,2 @@
+<?php
+header('Location: /');

--- a/v1/index.php
+++ b/v1/index.php
@@ -10,6 +10,7 @@ $endpoints = [
     '/core/version-check/1.0/',
     '/events/1.0/',
     '/features/1.0/',
+    '/feature-requests/1.0/',
     '/secret-key/1.0/salt/',
     '/migration/',
     '/translations/core/1.0.0/translations.json',


### PR DESCRIPTION
Fixes https://github.com/ClassicPress/ClassicPress/issues/1069

- [x] Add new endpoint querying GH issues for the dashboard widget.
- [ ] Needs to implement some kind of caching  to ensure the limit is not hit via GitHub. 

### Local Testing of the PR needs:
- A github app name
- A github token.

### Pre-merging:: On Caching
- There is an option of using [memcache](https://www.php.net/manual/en/memcache.set.php) if we support this on the server.
- Use a local file that is overwritten over a period of time. We have this previous with `bin/update-petitions-data.php` for `features/1.0` endpoint. The downside to this seems that the script is run manually. We would need to run some kind of cronjob. What is the possibility of this? @mattyrob 

### What to expect

#### Success
![CleanShot 2024-04-20 at 15 25 20](https://github.com/ClassicPress/ClassicPress-APIs/assets/7713923/348a611f-7f65-4327-8e7a-8a31e56b4031)

### Failed
![CleanShot 2024-04-20 at 15 45 58@2x](https://github.com/ClassicPress/ClassicPress-APIs/assets/7713923/756ff0dd-6ee5-49db-a068-3dcff53de1ba)

