### PR TITLE
Add API support for PHP 8.4

### DIFF
--- a/v1/migration/index.php
+++ b/v1/migration/index.php
@@ -46,8 +46,8 @@ echo json_encode( [
 	],
 	'php' => [
 		'min' => '7.4',
-		'max' => '8.3.999',
-		'max_display' => '8.3.x',
+		'max' => '8.4.999',
+		'max_display' => '8.4.x',
 	],
 	'links' => [
 		'ClassicPress v2'  => $build_url,


### PR DESCRIPTION
With the recent release of ClassicPress 2.3.0, there is now official support for PHP 8.4.

The migration endpoint needs updating to enable migrations from WordPress to ClassicPress on servers using PHP 8.4, especially as the migration endpoint now directly migrates to ClassicPress `2.3.1`.