### PR TITLE
Match API descriptions to core strings for translation

### DIFF
--- a/v1/core/importers/2.0/index.php
+++ b/v1/core/importers/2.0/index.php
@@ -9,43 +9,43 @@ echo json_encode([
     "importers" => [
         "blogger" => [
             "name" => "Blogger",
-            "description" => "Install the Blogger importer to import posts, comments, and users from a Blogger blog.",
+            "description" => "Import posts, comments, and users from a Blogger blog.",
             "plugin-slug" => "blogger-importer",
             "importer-id" => "blogger"
         ],
         "wpcat2tag" => [
             "name" => "Categories and Tags Converter",
-            "description" => "Install the category/tag converter to convert existing categories to tags or tags to categories, selectively.",
+            "description" => "Convert existing categories to tags or tags to categories, selectively.",
             "plugin-slug" => "wpcat2tag-importer",
             "importer-id" => "wpcat2tag"
         ],
         "livejournal" => [
             "name" => "LiveJournal",
-            "description" => "Install the LiveJournal importer to import posts from LiveJournal using their API.",
+            "description" => "Import posts from LiveJournal using their API.",
             "plugin-slug" => "livejournal-importer",
             "importer-id" => "livejournal"
         ],
         "movabletype" => [
             "name" => "Movable Type and TypePad",
-            "description" => "Install the Movable Type importer to import posts and comments from a Movable Type or TypePad blog.",
+            "description" => "Import posts and comments from a Movable Type or TypePad blog.",
             "plugin-slug" => "movabletype-importer",
             "importer-id" => "mt"
         ],
         "opml" => [
             "name" => "Blogroll",
-            "description" => "Install the blogroll importer to import links in OPML format.",
+            "description" => "Import links in OPML format.",
             "plugin-slug" => "opml-importer",
             "importer-id" => "opml"
         ],
         "rss" => [
             "name" => "RSS",
-            "description" => "Install the RSS importer to import posts from an RSS feed.",
+            "description" => "Import posts from an RSS feed.",
             "plugin-slug" => "rss-importer",
             "importer-id" => "rss"
         ],
         "tumblr" => [
             "name" => "Tumblr",
-            "description" => "Install the Tumblr importer to import posts & media from Tumblr using their API.",
+            "description" => "Import posts &amp; media from Tumblr using their API.",
             "plugin-slug" => "tumblr-importer",
             "importer-id" => "tumblr"
         ],


### PR DESCRIPTION
As reported by @Guido07111975, the descriptions of installable / installed Importers at Tools > Import are not all translated.

![Tools - Import](https://github.com/user-attachments/assets/5765c141-c10a-45e9-a6a8-b706df779e8d)

This is because the core strings defined and translatable in the array here:
https://github.com/ClassicPress/ClassicPress/blob/bb10bc89a8bf0045f8c5360e9e157e57f6f9adfa/src/wp-admin/includes/import.php#L183
Don't match the strings server in the Import API:
https://github.com/ClassicPress/ClassicPress-APIs/blob/main/v1/core/importers/2.0/index.php

This PR aims to match these strings in the API response ensuring translation of these strings in core will work.