### PR TITLE
Upgrade Python script dependencies

### DIFF
--- a/v1-upgrade-generator/requirements.txt
+++ b/v1-upgrade-generator/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2024.7.4
+certifi==2026.4.22
 gitpython==3.1.47
-semver==2.8.1
+semver==3.0.4
 urllib3==2.6.3


### PR DESCRIPTION
This PR upgrades the versions of `certifi` and `semver` used in the upgrade generator script.

Already manaully tested at https://api-v1-test.classicpress.net/